### PR TITLE
Fix issue for spacing on the home page

### DIFF
--- a/src/features/Home/PolygonBanner/index.tsx
+++ b/src/features/Home/PolygonBanner/index.tsx
@@ -4,7 +4,7 @@ import { bodyDarkGreen120, cardBackgroundGold60 } from "shared/styles/colors";
 import { bodySmallSegment18 } from "shared/styles/fonts";
 import { sectionInlinePadding } from "shared/styles/lengths";
 
-export function HomeBanner({ text }: { text: string }) {
+export function HomeBanner() {
   return (
     <div
       className={css`

--- a/src/features/Home/index.tsx
+++ b/src/features/Home/index.tsx
@@ -35,13 +35,13 @@ export function Home() {
           flex-flow: column;
         `}
       >
+        <HomeBanner />
         <div
           className={css`
             padding: 6rem 0;
             background: ${sectionBackgroundGold5};
           `}
         >
-          <HomeBanner />
           <HomeProductHero />
           <div id="download">
             <HomeTryIt />


### PR DESCRIPTION
Closes https://github.com/tallyhowallet/tallyho.org/issues/139

This PR updates the spacing for elements on the home page.

<img width="816" alt="Screenshot 2023-02-14 at 12 52 28" src="https://user-images.githubusercontent.com/23117945/218731068-06df4fb7-8767-43f6-b950-d2d71797300e.png">


<img width="1705" alt="Screenshot 2023-02-14 at 12 52 09" src="https://user-images.githubusercontent.com/23117945/218731037-0f9c78bf-6a1c-447a-b0d8-0365e9f39a04.png">
