### PR TITLE
Updated pledge signer tweet

### DIFF
--- a/src/features/Manifesto/ManifestoPanel/ManifestoPanelSigned/index.tsx
+++ b/src/features/Manifesto/ManifestoPanel/ManifestoPanelSigned/index.tsx
@@ -227,10 +227,10 @@ function TwitterShareButton({
       onClick={() => {
         openTwitterTweetIntent({
           text: [
-            `I’m in. 👋 @TallyHoOfficial #defendWeb3`,
+            `I’m in. 👋 @taho_xyz #defendWeb3`,
             `signed: ${signedMessage.signature}`,
             ``,
-            `https://twitter.com/TallyHoOfficial/status/1561739484600774656`,
+            `https://twitter.com/taho_xyz/status/1561739484600774656`,
           ].join(`\n`),
         });
         onShareBegin();


### PR DESCRIPTION
Updated Twitter handle and tweet link in the pledge signer "Share on Twitter" pop-up. Closes #149 

Test:

- [ ] The correct twitter handle appears in the tweet pop up
- [ ] The correct tweet link appears in the tweet pop up
- [ ] The tweet link directs to the right tweet on taho_xyz

<img width="847" alt="image" src="https://user-images.githubusercontent.com/104520552/220448034-7a5df99c-4af5-49bc-a6c1-93ca411715a7.png">
